### PR TITLE
update nix options to silence warning

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -21,7 +21,7 @@ in
         description = ''
           File containing the private key to sign the derivations with.
         '';
-      }; 
+      };
 
       publicKeyFile = lib.mkOption {
         type = types.nullOr types.path;
@@ -142,14 +142,15 @@ in
     };
 
     nix = {
-      binaryCaches = [
-        "http://127.0.0.1:12304/"
-      ];
-      binaryCachePublicKeys = [
-        (lib.mkIf (cfg.publicKeyFile != null) (builtins.readFile cfg.publicKeyFile))
-        (lib.mkIf (cfg.publicKey != null) cfg.publicKey)
-      ]; 
-
+      settings = {
+        substituters = [
+          "http://127.0.0.1:12304/"
+        ];
+        trusted-public-keys = [
+          (lib.mkIf (cfg.publicKeyFile != null) (builtins.readFile cfg.publicKeyFile))
+          (lib.mkIf (cfg.publicKey != null) cfg.publicKey)
+        ];
+      };
       extraOptions = lib.mkIf (cfg.globalCacheTTL != null) ''
         narinfo-cache-negative-ttl = ${toString cfg.globalCacheTTL}
         narinfo-cache-positive-ttl = ${toString cfg.globalCacheTTL}


### PR DESCRIPTION
Hello!

The nix module options have changed (mostly stuff is now located at `nix.settings`):
```
trace: warning: The option `nix.binaryCaches' defined in `/nix/store/mwckgsmvqily7njdxqqbl647fdsp0wna-source/hosts/common/global/peerix.nix' has been renamed to `nix.settings.substituters'.
trace: warning: The option `nix.binaryCachePublicKeys' defined in `/nix/store/mwckgsmvqily7njdxqqbl647fdsp0wna-source/hosts/common/global/peerix.nix' has been renamed to `nix.settings.trusted-public-keys'.
```

Here's a quick patch updating them to the newer versions.

Thanks!