### PR TITLE
Remove `niv` from development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           src = ./.;
 
           doCheck = false;
-    
+
           propagatedBuildInputs = with pkgs; [
             nix
             nix-serve
@@ -44,7 +44,6 @@
       devShell = pkgs.mkShell {
         buildInputs = with pkgs; [
           nix-serve
-          niv
           (python.withPackages (ps: packages))
         ];
       };


### PR DESCRIPTION
Niv isn't used by this project any more.
