### PR TITLE
Always create a separate user for Peerix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ These Options exist:
 |----------------------------------|----------------------------------------------------------------------------------------------|
 | `services.peerix.enable`         | Enables Peerix                                                                               |
 | `services.peerix.openFirewall`   | Open the neccessary firewall ports.                                                          |
-| `services.peerix.user`           | What user should the peerix service run under.                                               |
-| `services.peerix.group`          | What group should the peerix service run under.                                              |
 | `services.peerix.privateKeyFile` | A path to the file that contains the path to the private key to sign your derivations.       |
 | `services.peerix.publicKeyFile`  | A path to the file that contains the path to the public key so nix can verify the signature. |
 | `services.peerix.publicKey`      | Directly specifiy a public key for the binary caches.                                        |


### PR DESCRIPTION
Running as the special `nobody` user is unsafe, according to the logs for the systemd service.
