### PR TITLE
Add options to directly contact hosts by name or ip + disable broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,50 @@ to automatically use peernix.
 
 These Options exist:
 
-| Option                           | Description                                                                                  |
-|----------------------------------|----------------------------------------------------------------------------------------------|
-| `services.peerix.enable`         | Enables Peerix                                                                               |
-| `services.peerix.openFirewall`   | Open the neccessary firewall ports.                                                          |
-| `services.peerix.user`           | What user should the peerix service run under.                                               |
-| `services.peerix.group`          | What group should the peerix service run under.                                              |
-| `services.peerix.privateKeyFile` | A path to the file that contains the path to the private key to sign your derivations.       |
-| `services.peerix.publicKeyFile`  | A path to the file that contains the path to the public key so nix can verify the signature. |
-| `services.peerix.publicKey`      | Directly specifiy a public key for the binary caches.                                        |
+| Option                               | Description                                                                                  |
+|--------------------------------------|----------------------------------------------------------------------------------------------|
+| `services.peerix.enable`             | Enables Peerix                                                                               |
+| `services.peerix.openFirewall`       | Open the neccessary firewall ports.                                                          |
+| `services.peerix.user`               | What user should the peerix service run under.                                               |
+| `services.peerix.group`              | What group should the peerix service run under.                                              |
+| `services.peerix.privateKeyFile`     | A path to the file that contains the path to the private key to sign your derivations.       |
+| `services.peerix.publicKeyFile`      | A path to the file that contains the path to the public key so nix can verify the signature. |
+| `services.peerix.publicKey`          | Directly specifiy a public key for the binary caches.                                        |
+| `services.peerix.extraHosts`         | A list of IPs or hostnames to additionnally contact, directly.                               |
+| `services.peerix.disableBroadcast`   | Disables the use of broadcast interfaces.                                                    |
 
 To sign the peerix cache, you can use `nix-store --generate-binary-cache-key` to create keys to verify authenticity of
 the packages in each nix-store.
+
+Example of module
+-----------------
+This example module uses the following features:
+
+- generated public & private keys (recommended) ;
+- separate user resserved for peerix (recommended) ;
+- disables the broadcast (modify to your needs) ;
+- extra hosts not reachable through broadcast pings (modify to your needs);
+
+```nix
+# modules/peerix.nix
+_: {
+  services.peerix = {
+    enable = true;
+    openFirewall = true; # UDP/12304
+
+    privateKeyFile = ../secrets/peerix-private;
+    publicKeyFile = ../secrets/peerix-public;
+
+    user = "peerix";
+    group = "peerix";
+
+    disableBroadcast = true;
+    extraHosts = [ "my-nixos-computer-hostname" "42.42.42.1" ];
+  };
+  users.users.peerix = {
+    isSystemUser = true;
+    group = "peerix";
+  };
+  users.groups.peerix = { };
+}
+```


### PR DESCRIPTION
Following options are added
- extraHosts enables the specification of hostnames/ips to specifically contact
- disableBroadcast would avoid to use the broadcast addresses from the interfaces by default

Those options are added using two env variables:
- comma-separated PEERIX_EXTRA_HOSTS
- boolean PEERIX_DISABLE_BROADCAST (true or false in string)

Also puts a small example in the `README.MD`.

Use case:
1. Use a VPN such as tailscale, aka a mesh vpn to connect multiple computers together, independantly of the network
2. Broadcast interfaces are not a feature of any VPN 
3. Peerix can still be used accross networks thanks to a module defined such as:
   ```nix
    _: {
      services.peerix = {
        enable = true;
        openFirewall = true; # UDP/12304

        privateKeyFile = ../secrets/peerix-private;
        publicKeyFile = ../secrets/peerix-public;

        user = "peerix";
        group = "peerix";

        disableBroadcast = true;
        extraHosts = [ "my-nixos-computer-hostname" "42.42.42.1" ];
      };
      users.users.peerix = {
        isSystemUser = true;
        group = "peerix";
      };
      users.groups.peerix = { };
    }
    ```